### PR TITLE
Fixes deprecation warning caused by using nothing: true.

### DIFF
--- a/lib/petergate/action_controller/base.rb
+++ b/lib/petergate/action_controller/base.rb
@@ -112,7 +112,7 @@ module Petergate
 
       def forbidden!(msg = nil)
         respond_to do |format|
-          format.any(:js, :json, :xml) { render nothing: true, status: :forbidden }
+          format.any(:js, :json, :xml) { head :forbidden }
           format.html do
             destination = current_user.present? ? request.referrer || after_sign_in_path_for(current_user) : root_path
             redirect_to destination, notice: (msg || custom_message)

--- a/lib/petergate/action_controller/base.rb
+++ b/lib/petergate/action_controller/base.rb
@@ -103,7 +103,7 @@ module Petergate
 
       def unauthorized!
         respond_to do |format|
-          format.any(:js, :json, :xml) { render nothing: true, status: :unauthorized }
+          format.any(:js, :json, :xml) { head :unauthorized }
           format.html do
             authenticate_user! 
           end


### PR DESCRIPTION
When Petergate builds the response for unauthorized users who perform a protected controller action, it does so by using `nothing: true` in `render`.

I'm using Rails 5.0.7 and running the tests returns the following error for me:
```
DEPRECATION WARNING: `:nothing` option is deprecated and will be removed in Rails 5.1. 
Use `head` method to respond with empty response body. (called from block (2 levels) in <class:MyControllerTest> at ...
```

I fixed it by changing using head to response with headers only and an empty response body in `Petergate::ActionController::Base#forbidden!`
and 
`Petergate::ActionController::Base#unauthorized!`

This is the documentation for the `head` method https://api.rubyonrails.org/classes/ActionController/Head.html

Hope it helps!