### PR TITLE
Travis deprecation warnings fix

### DIFF
--- a/dummy/config/environments/test.rb
+++ b/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.
@@ -36,4 +36,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Makes sure the order when running tests continues to be :sorted for now, as opposed to :random (the Rails 5 default).
+  config.active_support.test_order = :sorted
 end

--- a/dummy/test/test_helper.rb
+++ b/dummy/test/test_helper.rb
@@ -19,7 +19,7 @@ class ActiveSupport::TestCase
 end
 
 class ActionController::TestCase
-  include Devise::TestHelpers
+  include Devise::Test::ControllerHelpers
   def create_user_and_login(email: "user@example.com", password: "youllneverguess")
     u = User.create(email: email, password: password, password_confirmation: password, roles: :user)
     sign_in(u) 

--- a/lib/petergate/action_controller/base.rb
+++ b/lib/petergate/action_controller/base.rb
@@ -112,7 +112,7 @@ module Petergate
 
       def forbidden!(msg = nil)
         respond_to do |format|
-          format.any(:js, :json, :xml) { render nothing: true, status: :forbidden }
+          format.any(:js, :json, :xml) { head :forbidden }
           format.html do
             destination = current_user.present? ? request.referrer || after_sign_in_path_for(current_user) : root_path
             redirect_to destination, notice: (msg || custom_message)

--- a/lib/petergate/action_controller/base.rb
+++ b/lib/petergate/action_controller/base.rb
@@ -103,7 +103,7 @@ module Petergate
 
       def unauthorized!
         respond_to do |format|
-          format.any(:js, :json, :xml) { render nothing: true, status: :unauthorized }
+          format.any(:js, :json, :xml) { head :unauthorized }
           format.html do
             authenticate_user! 
           end


### PR DESCRIPTION
The following errors were preventing Travis CI build from passing:
```
DEPRECATION WARNING: The configuration option `config.serve_static_assets` has been renamed to `config.serve_static_files` to clarify its role (it merely enables serving everything in the `public` folder and is unrelated to the asset pipeline). The `serve_static_assets` alias will be removed in Rails 5.0. Please migrate your configuration files accordingly. (called from block in <top (required)> at /home/travis/build/elorest/petergate/dummy/config/environments/test.rb:16)
```
```
DEPRECATION WARNING: [Devise] including `Devise::TestHelpers` is deprecated and will be removed from Devise.
For controller tests, please include `Devise::Test::ControllerHelpers` instead.
 (called from include at /home/travis/build/elorest/petergate/dummy/test/test_helper.rb:22)
```
```
DEPRECATION WARNING: You did not specify a value for the configuration option `active_support.test_order`. In Rails 5, the default value of this option will change from `:sorted` to `:random`.
To disable this warning and keep the current behavior, you can add the following line to your `config/environments/test.rb`:
  Rails.application.configure do
    config.active_support.test_order = :sorted
  end
Alternatively, you can opt into the future behavior by setting this option to `:random`. (called from test_order at /home/travis/.rvm/gems/ruby-2.3.1/gems/activesupport-4.2.7.1/lib/active_support/test_case.rb:42)
```

I fixed them by following the recommendations they included, and keeping the test execution order as :sorted (the value it originally had by default and changed as of Rails 5).