### PR TITLE
Carlosagp/update rails version support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.5.1'
 # Specify your gem's dependencies in petergate.gemspec
 gemspec
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 5.2.1'
+gem 'rails', '~> 6.0.3.4'
 
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
@@ -12,8 +12,6 @@ gem 'sqlite3'
 gem 'sass-rails', '~> 5.0.4'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
-# Use CoffeeScript for .js.coffee assets and views
-gem 'coffee-rails', '~> 4.2.2'
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 # gem 'therubyracer',  platforms: :ruby
 
@@ -21,7 +19,7 @@ gem 'coffee-rails', '~> 4.2.2'
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem 'turbolinks'
-gem "minitest-rails", "~> 3.0.0"
+gem "minitest-rails", "~> 6.0.1"
 gem "minitest-reporters"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'

--- a/dummy/app/assets/javascripts/blogs.js
+++ b/dummy/app/assets/javascripts/blogs.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/dummy/app/assets/javascripts/blogs.js.coffee
+++ b/dummy/app/assets/javascripts/blogs.js.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/lib/petergate/action_controller/base.rb
+++ b/lib/petergate/action_controller/base.rb
@@ -38,6 +38,7 @@ module Petergate
             end
 
             def inherited(subclass)
+              super
               subclass.instance_variable_set("@_controller_rules", instance_variable_get("@_controller_rules"))
               subclass.instance_variable_set("@_controller_message", instance_variable_get("@_controller_message"))
             end


### PR DESCRIPTION
# Fix compatibility issue with Rails version > 6.0.3

  - There is a call in ActionPack -> ActionController  action_controller/metal/parameter_encoding.rb to `#inherit` and was being overwritten in Petergate. This would cause the internal `@_parameter_encodings` environment variable to be nil and later on would cause a Nil reference error. 

# Update rails gem
# Remove Coffeescript